### PR TITLE
Auto refresh the oauth2 token

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run all tests including integration tests
       run: |
         cd mal
-        go test -v --access-token=${{ secrets.MAL_ACCESS_TOKEN }}
+        go test -v --client-id=${{ secrets.MAL_CLIENT_ID }} --oauth2-token=${{ secrets.MAL_OAUTH2_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run all tests including integration tests
       run: |
         cd mal
-        go test -v --client-id=${{ secrets.MAL_CLIENT_ID }} --oauth2-token=${{ secrets.MAL_OAUTH2_TOKEN }}
+        go test -v --client-id=${{ secrets.MAL_CLIENT_ID }} --oauth2-token='${{ secrets.MAL_OAUTH2_TOKEN }}'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run all tests including integration tests
       run: |
         cd mal
-        go test -v --client-id=${{ secrets.MAL_CLIENT_ID }} --oauth2-token='${{ secrets.MAL_OAUTH2_TOKEN }}'
+        go test -v --client-id=${{ secrets.MAL_CLIENT_ID }} --oauth2-token=${{ secrets.MAL_OAUTH2_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,12 @@
 name: tests
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
     - master
+    
   pull_request:
     branches:
     - master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: Run golint
       run: |
-        go install golang.org/x/lint/golint
+        go install golang.org/x/lint/golint@latest
         golint `go list ./... | grep -v /vendor/`
 
     - name: Run go test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,8 @@
 name: tests
 
 on:
-  workflow_dispatch:
-
   push:
-    branches:
-    - master
-    
+
   pull_request:
     branches:
     - master

--- a/README.md
+++ b/README.md
@@ -59,13 +59,25 @@ const storedToken = `
 }`
 
 oauth2Token := new(oauth2.Token)
-err := json.Unmarshal([]byte(storedToken), oauth2Token)
-// handle err...
+_ = json.Unmarshal([]byte(storedToken), oauth2Token)
 
-ctx := context.Background()
-c := mal.NewClient(
-	oauth2.NewClient(ctx, oauth2.StaticTokenSource(oauth2Token)),
-)
+// Create client ID and secret from https://myanimelist.net/apiconfig. 
+//
+// Secret is currently optional if you choose App Type 'other'.
+oauth2Conf := &oauth2.Config{
+    ClientID:     "<Enter your registered MyAnimeList.net application client ID>",
+    ClientSecret: "<Enter your registered MyAnimeList.net application client secret>",
+    Endpoint: oauth2.Endpoint{
+        AuthURL:   "https://myanimelist.net/v1/oauth2/authorize",
+        TokenURL:  "https://myanimelist.net/v1/oauth2/token",
+        AuthStyle: oauth2.AuthStyleInParams,
+    },
+}
+
+oauth2Client := oauth2Conf.Client(ctx, oauth2Token)
+
+// The oauth2Client will refresh the token if it expires.
+c := mal.NewClient(oauth2Client)
 ```
 
 Note that all calls made by the client above will include the specified oauth2

--- a/README.md
+++ b/README.md
@@ -45,25 +45,37 @@ the different MyAnimeList API methods.
 When creating a new client, pass an `http.Client` that can handle authentication
 for you. The recommended way is to use the `golang.org/x/oauth2` package
 (https://github.com/golang/oauth2). After performing the OAuth2 flow, you will
-get an access token which can be used like this:
+get an oauth2 token containing an access token, a refresh token and an
+expiration date. The oauth2 token can easily be stored in JSON format and used
+like this:
 
 ```go
+const storedToken = `
+{
+	"token_type": "Bearer",
+	"access_token": "yourAccessToken",
+	"refresh_token": "yourRefreshToken",
+	"expiry": "2021-06-01T16:12:56.1319122Z"
+}`
+
+oauth2Token := new(oauth2.Token)
+err := json.Unmarshal([]byte(storedToken), oauth2Token)
+// handle err...
+
 ctx := context.Background()
 c := mal.NewClient(
-	oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: "<your access token>"},
-	)),
+	oauth2.NewClient(ctx, oauth2.StaticTokenSource(oauth2Token)),
 )
 ```
 
-Note that all calls made by the client above will include the specified access
+Note that all calls made by the client above will include the specified oauth2
 token which is specific for an authenticated user. Therefore, authenticated
 clients should almost never be shared between different users.
 
 Performing the OAuth2 flow involves registering a MAL API application and then
 asking for the user's consent to allow the application to access their data.
 
-There is a detailed example of how to perform the Oauth2 flow and get an access
+There is a detailed example of how to perform the Oauth2 flow and get an oauth2
 token through the terminal under `example/malauth`. The only thing you need to run
 the example is a client ID and a client secret which you can acquire after
 registering your MAL API application. Here's how:
@@ -84,7 +96,7 @@ ID and client secret through flags:
     go install github.com/nstratos/go-myanimelist/example/malauth
     malauth --client-id=... --client-secret=...
 
-After you perform a successful authentication once, the access token will be
+After you perform a successful authentication once, the oauth2 token will be
 cached in a file under the same directory which makes it easier to run the
 example multiple times.
 
@@ -307,13 +319,13 @@ also a much higher chance of false positives in test failures due to network
 issues etc.
 
 These tests are meant to be run using a dedicated test account that contains
-empty anime and manga lists. A valid access token needs to be provided every
+empty anime and manga lists. A valid oauth2 token needs to be provided every
 time. Check the authentication section to learn how to get one.
 
-By default the integration tests are skipped when an access token is not
+By default the integration tests are skipped when an oauth2 token is not
 provided. To run all tests including the integration tests:
 
-	go test --access-token '<your access token>'
+	go test --client-id='<your app client ID>' --oauth2-token='<your oauth2 token>'
 
 ## License
 

--- a/mal/doc.go
+++ b/mal/doc.go
@@ -26,23 +26,35 @@ Authentication
 When creating a new client, pass an http.Client that can handle authentication
 for you. The recommended way is to use the golang.org/x/oauth2 package
 (https://github.com/golang/oauth2). After performing the OAuth2 flow, you will
-get an access token which can be used like this:
+get an oauth2 token containing an access token, a refresh token and an
+expiration date. The oauth2 token can easily be stored in JSON format and used
+like this:
+
+	const storedToken = `
+	{
+		"token_type": "Bearer",
+		"access_token": "yourAccessToken",
+		"refresh_token": "yourRefreshToken",
+		"expiry": "2021-06-01T16:12:56.1319122Z"
+	}`
+
+	oauth2Token := new(oauth2.Token)
+	err := json.Unmarshal([]byte(storedToken), oauth2Token)
+	// handle err...
 
 	ctx := context.Background()
 	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
+		oauth2.NewClient(ctx, oauth2.StaticTokenSource(oauth2Token)),
 	)
 
-Note that all calls made by the client above will include the specified access
+Note that all calls made by the client above will include the specified oauth2
 token which is specific for an authenticated user. Therefore, authenticated
 clients should almost never be shared between different users.
 
 Performing the OAuth2 flow involves registering a MAL API application and then
 asking for the user's consent to allow the application to access their data.
 
-There is a detailed example of how to perform the Oauth2 flow and get an access
+There is a detailed example of how to perform the Oauth2 flow and get an oauth2
 token through the terminal under example/malauth. The only thing you need to run
 the example is a client ID and a client secret which you can acquire after
 registering your MAL API application. Here's how:
@@ -63,7 +75,7 @@ ID and client secret through flags:
 	go install github.com/nstratos/go-myanimelist/example/malauth
 	malauth --client-id=... --client-secret=...
 
-After you perform a successful authentication once, the access token will be
+After you perform a successful authentication once, the oauth2 token will be
 cached in a file under the same directory which makes it easier to run the
 example multiple times.
 
@@ -272,13 +284,13 @@ also a much higher chance of false positives in test failures due to network
 issues etc.
 
 These tests are meant to be run using a dedicated test account that contains
-empty anime and manga lists. A valid access token needs to be provided every
+empty anime and manga lists. A valid oauth2 token needs to be provided every
 time. Check the authentication section to learn how to get one.
 
-By default the integration tests are skipped when an access token is not
+By default the integration tests are skipped when an oauth2 token is not
 provided. To run all tests including the integration tests:
 
-	go test --access-token '<your access token>'
+	go test --client-id='<your app client ID>' --oauth2-token='<your oauth2 token>'
 
 License
 

--- a/mal/doc.go
+++ b/mal/doc.go
@@ -39,13 +39,25 @@ like this:
 	}`
 
 	oauth2Token := new(oauth2.Token)
-	err := json.Unmarshal([]byte(storedToken), oauth2Token)
-	// handle err...
+	_ = json.Unmarshal([]byte(storedToken), oauth2Token)
 
-	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(oauth2Token)),
-	)
+	// Create client ID and secret from https://myanimelist.net/apiconfig.
+	//
+	// Secret is currently optional if you choose App Type 'other'.
+	oauth2Conf := &oauth2.Config{
+		ClientID:     "<Enter your registered MyAnimeList.net application client ID>",
+		ClientSecret: "<Enter your registered MyAnimeList.net application client secret>",
+		Endpoint: oauth2.Endpoint{
+		    AuthURL:   "https://myanimelist.net/v1/oauth2/authorize",
+		    TokenURL:  "https://myanimelist.net/v1/oauth2/token",
+		    AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	oauth2Client := oauth2Conf.Client(ctx, oauth2Token)
+
+	// The oauth2Client will refresh the token if it expires.
+	c := mal.NewClient(oauth2Client)
 
 Note that all calls made by the client above will include the specified oauth2
 token which is specific for an authenticated user. Therefore, authenticated

--- a/mal/example_anime_test.go
+++ b/mal/example_anime_test.go
@@ -8,16 +8,12 @@ import (
 	"strings"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleAnimeService_List() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples
@@ -45,13 +41,11 @@ func ExampleAnimeService_List() {
 
 func ExampleAnimeService_Details() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -110,13 +104,11 @@ func ExampleAnimeService_Details() {
 
 func ExampleAnimeService_Ranking() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -144,13 +136,11 @@ func ExampleAnimeService_Ranking() {
 
 func ExampleAnimeService_Seasonal() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -176,13 +166,11 @@ func ExampleAnimeService_Seasonal() {
 
 func ExampleAnimeService_Suggested() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -206,13 +194,11 @@ func ExampleAnimeService_Suggested() {
 
 func ExampleAnimeService_DeleteMyListItem() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_anime_test.go
+++ b/mal/example_anime_test.go
@@ -19,7 +19,8 @@ func ExampleAnimeService_List() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_forum_test.go
+++ b/mal/example_forum_test.go
@@ -77,7 +77,8 @@ func ExampleForumService_Topics() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_forum_test.go
+++ b/mal/example_forum_test.go
@@ -6,18 +6,15 @@ import (
 	"net/url"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleForumService_Boards() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -71,11 +68,8 @@ func ExampleForumService_Boards() {
 
 func ExampleForumService_Topics() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples
@@ -102,13 +96,11 @@ func ExampleForumService_Topics() {
 
 func ExampleForumService_TopicDetails() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_manga_test.go
+++ b/mal/example_manga_test.go
@@ -7,16 +7,12 @@ import (
 	"strings"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleMangaService_List() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples
@@ -44,13 +40,11 @@ func ExampleMangaService_List() {
 
 func ExampleMangaService_Details() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -106,13 +100,11 @@ func ExampleMangaService_Details() {
 
 func ExampleMangaService_Ranking() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)
@@ -140,13 +132,11 @@ func ExampleMangaService_Ranking() {
 
 func ExampleMangaService_DeleteMyListItem() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_manga_test.go
+++ b/mal/example_manga_test.go
@@ -18,7 +18,8 @@ func ExampleMangaService_List() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_oauth2_test.go
+++ b/mal/example_oauth2_test.go
@@ -1,0 +1,65 @@
+package mal_test
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/nstratos/go-myanimelist/mal"
+	"golang.org/x/oauth2"
+)
+
+func newOAuth2Client(ctx context.Context) *http.Client {
+	// In order to create a client ID and secret for your application:
+	//
+	//  1. Navigate to https://myanimelist.net/apiconfig or go to your MyAnimeList
+	//     profile, click Edit Profile and select the API tab on the far right.
+	//  2. Click Create ID and submit the form with your application details.
+	oauth2Conf := &oauth2.Config{
+		ClientID:     "<Enter your MyAnimeList.net application client ID>",
+		ClientSecret: "<Enter your MyAnimeList.net application client secret>", // Optional if you chose App Type 'other'.
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   "https://myanimelist.net/v1/oauth2/authorize",
+			TokenURL:  "https://myanimelist.net/v1/oauth2/token",
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	// To get your first token you need to complete the oauth2 flow. There is a
+	// detailed example that uses the terminal under `example/malauth` which you
+	// should adjust for your application.
+	//
+	// Here we assume we have already received our first valid token and stored
+	// it somewhere in JSON format.
+	const storedToken = `
+	{
+		"token_type": "Bearer",
+		"access_token": "yourAccessToken",
+		"refresh_token": "yourRefreshToken",
+		"expiry": "2021-06-01T16:12:56.1319122Z"
+	}`
+
+	// Decode stored token to oauth2.Token struct.
+	oauth2Token := new(oauth2.Token)
+	_ = json.Unmarshal([]byte(storedToken), oauth2Token)
+
+	// The oauth2 client returned here with the above configuration and valid
+	// token will refresh the token seamlessly when it expires.
+	return oauth2Conf.Client(ctx, oauth2Token)
+}
+
+func Example_oAuth2() {
+	ctx := context.Background()
+	oauth2Client := newOAuth2Client(ctx)
+
+	c := mal.NewClient(oauth2Client)
+
+	user, _, err := c.User.MyInfo(ctx)
+	if err != nil {
+		fmt.Printf("User.MyInfo error: %v", err)
+		return
+	}
+	fmt.Printf("ID: %5d, Joined: %v, Username: %s\n", user.ID, user.JoinedAt.Format("Jan 2006"), user.Name)
+}

--- a/mal/example_user_test.go
+++ b/mal/example_user_test.go
@@ -6,16 +6,12 @@ import (
 	"net/url"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleUserService_MyInfo() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples

--- a/mal/example_user_test.go
+++ b/mal/example_user_test.go
@@ -17,7 +17,8 @@ func ExampleUserService_MyInfo() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_useranimelist_test.go
+++ b/mal/example_useranimelist_test.go
@@ -17,7 +17,8 @@ func ExampleUserService_AnimeList() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_useranimelist_test.go
+++ b/mal/example_useranimelist_test.go
@@ -6,16 +6,12 @@ import (
 	"net/url"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleUserService_AnimeList() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples
@@ -45,13 +41,11 @@ func ExampleUserService_AnimeList() {
 
 func ExampleAnimeService_UpdateMyListStatus() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_usermangalist_test.go
+++ b/mal/example_usermangalist_test.go
@@ -17,7 +17,8 @@ func ExampleUserService_MangaList() {
 		)),
 	)
 
-	// Use a stub server instead of the real API.
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/example_usermangalist_test.go
+++ b/mal/example_usermangalist_test.go
@@ -6,16 +6,12 @@ import (
 	"net/url"
 
 	"github.com/nstratos/go-myanimelist/mal"
-	"golang.org/x/oauth2"
 )
 
 func ExampleUserService_MangaList() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
+
+	c := mal.NewClient(nil)
 
 	// Ignore the 3 following lines. A stub server is used instead of the real
 	// API to produce testable examples. See: https://go.dev/blog/examples
@@ -42,13 +38,11 @@ func ExampleUserService_MangaList() {
 
 func ExampleMangaService_UpdateMyListStatus() {
 	ctx := context.Background()
-	c := mal.NewClient(
-		oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: "<your access token>"},
-		)),
-	)
 
-	// Use a stub server instead of the real API.
+	c := mal.NewClient(nil)
+
+	// Ignore the 3 following lines. A stub server is used instead of the real
+	// API to produce testable examples. See: https://go.dev/blog/examples
 	server := newStubServer()
 	defer server.Close()
 	c.BaseURL, _ = url.Parse(server.URL)

--- a/mal/integration_test.go
+++ b/mal/integration_test.go
@@ -40,7 +40,8 @@ func setup(ctx context.Context, t *testing.T) *mal.Client {
 	if err != nil {
 		t.Logf("The oauth2 token is expected to be in JSON format, example: %s", tokenFormat)
 		t.Log(`Note: On some terminals you may need to escape the double quotes: --oauth2-token='{\"token_type\":\"Bearer\",...'`)
-		t.Fatalf("failed to unmarshal oauth2 token: %v", err)
+		t.Logf("failed to unmarshal oauth2 token: %v", err)
+		t.Fatalf("input was:\n%s", *oauth2Token)
 	}
 
 	conf := &oauth2.Config{

--- a/mal/integration_test.go
+++ b/mal/integration_test.go
@@ -41,7 +41,7 @@ func setup(ctx context.Context, t *testing.T) *mal.Client {
 		t.Logf("The oauth2 token is expected to be in JSON format, example: %s", tokenFormat)
 		t.Log(`Note: On some terminals you may need to escape the double quotes: --oauth2-token='{\"token_type\":\"Bearer\",...'`)
 		t.Logf("failed to unmarshal oauth2 token: %v", err)
-		t.Fatalf("input was:\n%s", *oauth2Token)
+		t.Fatalf("input was:\n%q", *oauth2Token)
 	}
 
 	conf := &oauth2.Config{

--- a/mal/mal.go
+++ b/mal/mal.go
@@ -13,20 +13,6 @@ import (
 	"strings"
 )
 
-// Anime and manga entries have a status such as completed, on hold and
-// dropped.
-//
-// Current is for entries marked as currently watching or reading.
-//
-// Planned is for entries marked as plan to watch or read.
-// const (
-// 	Current   Status = 1
-// 	Completed        = 2
-// 	OnHold           = 3
-// 	Dropped          = 4
-// 	Planned          = 6
-// )
-
 const (
 	defaultBaseURL = "https://api.myanimelist.net/v2/"
 )

--- a/mal/mal.go
+++ b/mal/mal.go
@@ -13,9 +13,6 @@ import (
 	"strings"
 )
 
-// Status specifies a status for anime and manga entries.
-//type Status int
-
 // Anime and manga entries have a status such as completed, on hold and
 // dropped.
 //


### PR DESCRIPTION
This change uses the whole oauth2 token for authentication which
includes type, access token, refresh token and expiration (previously
only the access token was used).

By using all the info of the oauth2 token and especially the refresh
token, the oauth2 client can now seamlessly refresh the oauth2 token
when it expires.

The documentation and examples have been updated accordingly.