### PR TITLE
Remove deprecated caching from test action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,22 +21,15 @@ jobs:
 
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Download go modules
       run: go mod download
-
-    - name: Cache go modules
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-go-
 
     - name: Mod verify
       run: go mod verify


### PR DESCRIPTION
- Remove caching of go modules from the test action since actions/cache is
deprecated. Caching is done by actions/setup-go by default.
- Update actions/setup-go@v2 to v5
- Update actions/checkout@v2 to v4